### PR TITLE
Profile-S4 - Избранные NFT и финализация профиля

### DIFF
--- a/iOS-FakeNFT-Extended/App/Router/Routes.swift
+++ b/iOS-FakeNFT-Extended/App/Router/Routes.swift
@@ -14,7 +14,7 @@ enum CartRoute: Hashable {
 
 enum ProfileRoute: Hashable {
     case myNfts([String])
-    case favorites(Profile)
+    case favorites([String])
     case edit(Profile)
     case userWeb(URL)
 }

--- a/iOS-FakeNFT-Extended/App/Router/Routes.swift
+++ b/iOS-FakeNFT-Extended/App/Router/Routes.swift
@@ -14,7 +14,7 @@ enum CartRoute: Hashable {
 
 enum ProfileRoute: Hashable {
     case myNfts([String])
-    case favorites
+    case favorites(Profile)
     case edit(Profile)
     case userWeb(URL)
 }

--- a/iOS-FakeNFT-Extended/Services/Profile/MockProfileService.swift
+++ b/iOS-FakeNFT-Extended/Services/Profile/MockProfileService.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-actor MockProfileService: ProfileServiceProtocol, NftServiceProtocol {
+enum ProfilePreviewData {
 
     // MARK: - Test Data
 
@@ -47,6 +47,9 @@ actor MockProfileService: ProfileServiceProtocol, NftServiceProtocol {
         nfts: nfts.compactMap(\.id),
         likes: Array(nfts.compactMap(\.id).suffix(2))
     )
+}
+
+actor MockProfileService: ProfileServiceProtocol {
 
     // MARK: - State
 
@@ -54,7 +57,7 @@ actor MockProfileService: ProfileServiceProtocol, NftServiceProtocol {
 
     // MARK: - Initializers
 
-    init(profile: Profile = MockProfileService.profile) {
+    init(profile: Profile = ProfilePreviewData.profile) {
         currentProfile = profile
     }
 
@@ -68,11 +71,14 @@ actor MockProfileService: ProfileServiceProtocol, NftServiceProtocol {
         currentProfile = profile
         return profile
     }
+}
+
+actor MockNftService: NftServiceProtocol {
 
     // MARK: - NftServiceProtocol
 
     func loadNft(id: String) async throws -> ProfileNft {
-        guard let nft = Self.nfts.first(where: { $0.id == id }) else {
+        guard let nft = ProfilePreviewData.nfts.first(where: { $0.id == id }) else {
             throw URLError(.fileDoesNotExist)
         }
 

--- a/iOS-FakeNFT-Extended/Services/Requests/UpdateProfileRequest.swift
+++ b/iOS-FakeNFT-Extended/Services/Requests/UpdateProfileRequest.swift
@@ -37,7 +37,18 @@ struct UpdateProfileRequest: NetworkRequest {
             ("description", profile.description ?? ""),
             ("avatar", profile.avatar ?? ""),
             ("website", profile.website ?? "")
-        ] + (profile.likes ?? []).map { ("likes", $0) }
+        ] + likesFormItems
+    }
+
+    private var likesFormItems: [(String, String)] {
+        guard let likes = profile.likes else { return [] }
+        guard !likes.isEmpty else { return [("likes", Constants.emptyLikesValue)] }
+
+        return likes.map { ("likes", $0) }
+    }
+
+    private enum Constants {
+        static let emptyLikesValue = "null"
     }
 }
 

--- a/iOS-FakeNFT-Extended/UI/Profile/ViewModels/FavoriteNFTsViewModel.swift
+++ b/iOS-FakeNFT-Extended/UI/Profile/ViewModels/FavoriteNFTsViewModel.swift
@@ -1,0 +1,171 @@
+//
+//  FavoriteNFTsViewModel.swift
+//  iOS-FakeNFT-Extended
+//
+//  Created by Анастасия Федотова on 19.05.2026.
+//
+
+import Foundation
+import Observation
+
+@Observable
+@MainActor
+final class FavoriteNFTsViewModel {
+
+    // MARK: - State
+
+    enum State {
+        case idle
+        case loading
+        case loaded([ProfileNft])
+        case empty
+        case failed(String)
+    }
+
+    private(set) var state: State = .idle
+    private(set) var currentProfile: Profile
+    private(set) var pendingRemovalIds: Set<String> = []
+    private var failedRemovalNFT: ProfileNft?
+    var removalErrorMessage: String?
+
+    // MARK: - Dependencies
+
+    private let nftService: NftServiceProtocol
+    private let profileService: ProfileServiceProtocol
+
+    // MARK: - Initializers
+
+    init(
+        profile: Profile,
+        nftService: NftServiceProtocol,
+        profileService: ProfileServiceProtocol
+    ) {
+        currentProfile = profile
+        self.nftService = nftService
+        self.profileService = profileService
+    }
+
+    // MARK: - Public Methods
+
+    func loadNFTs() async {
+        guard !state.isLoading else { return }
+
+        let likes = currentProfile.likes ?? []
+        guard !likes.isEmpty else {
+            state = .empty
+            return
+        }
+
+        state = .loading
+        removalErrorMessage = nil
+
+        do {
+            let nfts = try await withThrowingTaskGroup(of: ProfileNft.self) { group in
+                for nftId in likes {
+                    group.addTask { [nftService] in
+                        try await nftService.loadNft(id: nftId)
+                    }
+                }
+
+                var loadedNFTs: [ProfileNft] = []
+                for try await nft in group {
+                    loadedNFTs.append(nft)
+                }
+
+                return loadedNFTs
+            }
+
+            state = nfts.isEmpty ? .empty : .loaded(nfts)
+        } catch {
+            state = .failed(
+                String(
+                    format: String(localized: "Profile.FavoriteNFTs.error.load"),
+                    error.localizedDescription
+                )
+            )
+        }
+    }
+
+    func removeFromFavorites(_ nft: ProfileNft) async -> Profile? {
+        guard let nftId = nft.id,
+              !pendingRemovalIds.contains(nftId) else {
+            return nil
+        }
+
+        let previousProfile = currentProfile
+        let previousState = state
+        let updatedLikes = (currentProfile.likes ?? []).filter { $0 != nftId }
+        let updatedProfile = currentProfile.updatingLikes(updatedLikes)
+
+        pendingRemovalIds.insert(nftId)
+        removalErrorMessage = nil
+        currentProfile = updatedProfile
+        removeNFTFromState(id: nftId)
+
+        do {
+            let savedProfile = try await profileService.updateProfile(updatedProfile)
+            currentProfile = savedProfile.updatingLikes(updatedLikes)
+            pendingRemovalIds.remove(nftId)
+            failedRemovalNFT = nil
+            return currentProfile
+        } catch {
+            currentProfile = previousProfile
+            state = previousState
+            pendingRemovalIds.remove(nftId)
+            failedRemovalNFT = nft
+            removalErrorMessage = String(
+                format: String(localized: "Profile.FavoriteNFTs.error.remove"),
+                error.localizedDescription
+            )
+            return nil
+        }
+    }
+
+    func retryFailedRemoval() async -> Profile? {
+        guard let failedRemovalNFT else { return nil }
+        return await removeFromFavorites(failedRemovalNFT)
+    }
+
+    func dismissRemovalError() {
+        removalErrorMessage = nil
+    }
+
+    // MARK: - Private Methods
+
+    private func removeNFTFromState(id: String) {
+        guard case .loaded(let nfts) = state else {
+            state = (currentProfile.likes ?? []).isEmpty ? .empty : state
+            return
+        }
+
+        let updatedNFTs = nfts.filter { $0.id != id }
+        state = updatedNFTs.isEmpty ? .empty : .loaded(updatedNFTs)
+    }
+}
+
+// MARK: - FavoriteNFTsViewModel.State
+
+private extension FavoriteNFTsViewModel.State {
+    var isLoading: Bool {
+        if case .loading = self {
+            return true
+        }
+        return false
+    }
+}
+
+// MARK: - Profile
+
+private extension Profile {
+    func updatingLikes(_ likes: [String]) -> Profile {
+        Profile(
+            id: id,
+            name: name,
+            description: description,
+            website: website,
+            avatar: avatar,
+            nfts: nfts ?? [],
+            likes: likes
+        )
+    }
+}

--- a/iOS-FakeNFT-Extended/UI/Profile/ViewModels/FavoriteNFTsViewModel.swift
+++ b/iOS-FakeNFT-Extended/UI/Profile/ViewModels/FavoriteNFTsViewModel.swift
@@ -23,7 +23,7 @@ final class FavoriteNFTsViewModel {
     }
 
     private(set) var state: State = .idle
-    private(set) var currentProfile: Profile
+    private(set) var favoriteIds: [String]
     private(set) var pendingRemovalIds: Set<String> = []
     private var failedRemovalNFT: ProfileNft?
     var removalErrorMessage: String?
@@ -31,18 +31,18 @@ final class FavoriteNFTsViewModel {
     // MARK: - Dependencies
 
     private let nftService: NftServiceProtocol
-    private let profileService: ProfileServiceProtocol
+    private let updateFavoriteIds: ([String]) async throws -> Profile
 
     // MARK: - Initializers
 
     init(
-        profile: Profile,
+        favoriteIds: [String],
         nftService: NftServiceProtocol,
-        profileService: ProfileServiceProtocol
+        updateFavoriteIds: @escaping ([String]) async throws -> Profile
     ) {
-        currentProfile = profile
+        self.favoriteIds = favoriteIds
         self.nftService = nftService
-        self.profileService = profileService
+        self.updateFavoriteIds = updateFavoriteIds
     }
 
     // MARK: - Public Methods
@@ -50,8 +50,7 @@ final class FavoriteNFTsViewModel {
     func loadNFTs() async {
         guard !state.isLoading else { return }
 
-        let likes = currentProfile.likes ?? []
-        guard !likes.isEmpty else {
+        guard !favoriteIds.isEmpty else {
             state = .empty
             return
         }
@@ -61,7 +60,7 @@ final class FavoriteNFTsViewModel {
 
         do {
             let nfts = try await withThrowingTaskGroup(of: ProfileNft.self) { group in
-                for nftId in likes {
+                for nftId in favoriteIds {
                     group.addTask { [nftService] in
                         try await nftService.loadNft(id: nftId)
                     }
@@ -92,24 +91,23 @@ final class FavoriteNFTsViewModel {
             return nil
         }
 
-        let previousProfile = currentProfile
+        let previousFavoriteIds = favoriteIds
         let previousState = state
-        let updatedLikes = (currentProfile.likes ?? []).filter { $0 != nftId }
-        let updatedProfile = currentProfile.updatingLikes(updatedLikes)
+        let updatedFavoriteIds = favoriteIds.filter { $0 != nftId }
 
         pendingRemovalIds.insert(nftId)
         removalErrorMessage = nil
-        currentProfile = updatedProfile
+        favoriteIds = updatedFavoriteIds
         removeNFTFromState(id: nftId)
 
         do {
-            let savedProfile = try await profileService.updateProfile(updatedProfile)
-            currentProfile = savedProfile.updatingLikes(updatedLikes)
+            let savedProfile = try await updateFavoriteIds(updatedFavoriteIds)
+            favoriteIds = savedProfile.likes ?? updatedFavoriteIds
             pendingRemovalIds.remove(nftId)
             failedRemovalNFT = nil
-            return currentProfile
+            return savedProfile
         } catch {
-            currentProfile = previousProfile
+            favoriteIds = previousFavoriteIds
             state = previousState
             pendingRemovalIds.remove(nftId)
             failedRemovalNFT = nft
@@ -134,7 +132,7 @@ final class FavoriteNFTsViewModel {
 
     private func removeNFTFromState(id: String) {
         guard case .loaded(let nfts) = state else {
-            state = (currentProfile.likes ?? []).isEmpty ? .empty : state
+            state = favoriteIds.isEmpty ? .empty : state
             return
         }
 
@@ -151,21 +149,5 @@ private extension FavoriteNFTsViewModel.State {
             return true
         }
         return false
-    }
-}
-
-// MARK: - Profile
-
-private extension Profile {
-    func updatingLikes(_ likes: [String]) -> Profile {
-        Profile(
-            id: id,
-            name: name,
-            description: description,
-            website: website,
-            avatar: avatar,
-            nfts: nfts ?? [],
-            likes: likes
-        )
     }
 }

--- a/iOS-FakeNFT-Extended/UI/Profile/ViewModels/ProfileViewModel.swift
+++ b/iOS-FakeNFT-Extended/UI/Profile/ViewModels/ProfileViewModel.swift
@@ -62,6 +62,19 @@ final class ProfileViewModel {
     func updateLoadedProfile(_ profile: Profile) {
         state = .loaded(profile)
     }
+
+    func updateFavoriteIds(_ favoriteIds: [String]) async throws -> Profile {
+        guard let profile = loadedProfile else {
+            throw URLError(.badServerResponse)
+        }
+
+        let updatedProfile = profile.updatingLikes(favoriteIds)
+        let savedProfile = try await profileService.updateProfile(updatedProfile)
+        let actualProfile = savedProfile.updatingLikes(favoriteIds)
+        state = .loaded(actualProfile)
+
+        return actualProfile
+    }
 }
 
 // MARK: - ProfileViewModel.State
@@ -72,5 +85,21 @@ private extension ProfileViewModel.State {
             return true
         }
         return false
+    }
+}
+
+// MARK: - Profile
+
+private extension Profile {
+    func updatingLikes(_ likes: [String]) -> Profile {
+        Profile(
+            id: id,
+            name: name,
+            description: description,
+            website: website,
+            avatar: avatar,
+            nfts: nfts ?? [],
+            likes: likes
+        )
     }
 }

--- a/iOS-FakeNFT-Extended/UI/Profile/Views/FavoriteNFTCell.swift
+++ b/iOS-FakeNFT-Extended/UI/Profile/Views/FavoriteNFTCell.swift
@@ -1,0 +1,202 @@
+//
+//  FavoriteNFTCell.swift
+//  iOS-FakeNFT-Extended
+//
+//  Created by Анастасия Федотова on 19.05.2026.
+//
+
+import Kingfisher
+import SwiftUI
+
+struct FavoriteNFTCell: View {
+
+    // MARK: - Properties
+
+    let nft: ProfileNft
+    let isRemoving: Bool
+    let onRemove: () -> Void
+
+    // MARK: - Body
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            imageWithRemoveButton
+            infoBlock
+        }
+        .frame(maxWidth: .infinity, minHeight: 80, maxHeight: 80, alignment: .leading)
+    }
+
+    // MARK: - Content
+
+    private var imageWithRemoveButton: some View {
+        ZStack(alignment: .topTrailing) {
+            FavoriteNFTImageView(url: imageURL)
+
+            Button(action: onRemove) {
+                Image(.favouritesActive)
+                    .renderingMode(.original)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 40, height: 40)
+                    .contentShape(Rectangle())
+                    .opacity(isRemoving ? 0.4 : 1)
+            }
+            .buttonStyle(.plain)
+            .disabled(isRemoving)
+        }
+        .frame(width: 80, height: 80)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private var infoBlock: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(nft.name ?? String(localized: "Profile.MyNFTs.unknownName"))
+                .font(.bold17)
+                .foregroundStyle(Color.ypBlack)
+                .lineLimit(1)
+
+            FavoriteRatingStarsView(rating: nft.rating ?? 0)
+                .padding(.top, 4)
+
+            Text(priceText)
+                .font(.regular15)
+                .foregroundStyle(Color.ypBlack)
+                .lineLimit(1)
+                .padding(.top, 8)
+        }
+        .frame(maxWidth: .infinity, minHeight: 80, maxHeight: 80, alignment: .topLeading)
+    }
+
+    // MARK: - Helpers
+
+    private var imageURL: URL? {
+        guard let image = nft.images?.first else {
+            return nil
+        }
+
+        return URL(string: image)
+    }
+
+    private var priceText: String {
+        guard let price = nft.price else {
+            return String(localized: "Profile.MyNFTs.noPrice")
+        }
+
+        return String(format: "%.2f ETH", locale: Locale(identifier: "ru_RU"), price)
+    }
+}
+
+// MARK: - FavoriteNFTImageView
+
+private struct FavoriteNFTImageView: View {
+
+    // MARK: - State
+
+    @State private var didFail = false
+
+    // MARK: - Properties
+
+    let url: URL?
+
+    // MARK: - Body
+
+    var body: some View {
+        ZStack {
+            if let url, !didFail {
+                KFImage(url)
+                    .placeholder {
+                        ZStack {
+                            Color.ypBackgroundUniversal
+
+                            LoadingSpinner(size: .medium, tint: .ypWhiteUniversal)
+                        }
+                    }
+                    .retry(maxCount: 2, interval: .seconds(1))
+                    .fade(duration: 0.2)
+                    .onFailure { _ in
+                        didFail = true
+                    }
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                FavoriteNFTImagePlaceholder()
+            }
+        }
+        .frame(width: 80, height: 80)
+        .clipped()
+    }
+}
+
+// MARK: - FavoriteNFTImagePlaceholder
+
+private struct FavoriteNFTImagePlaceholder: View {
+
+    // MARK: - Constants
+
+    private enum Constants {
+        static let cellSize: CGFloat = 20
+        static let gridSize = 4
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ForEach(0..<Constants.gridSize, id: \.self) { row in
+                HStack(spacing: 0) {
+                    ForEach(0..<Constants.gridSize, id: \.self) { column in
+                        Rectangle()
+                            .fill((row + column).isMultiple(of: 2) ? Color.ypWhite : Color.ypBlack)
+                            .frame(width: Constants.cellSize, height: Constants.cellSize)
+                    }
+                }
+            }
+        }
+        .frame(width: 80, height: 80)
+    }
+}
+
+// MARK: - FavoriteRatingStarsView
+
+private struct FavoriteRatingStarsView: View {
+
+    // MARK: - Constants
+
+    private enum Constants {
+        static let maxRating = 5
+        static let starSize: CGFloat = 12
+        static let totalWidth: CGFloat = 60
+    }
+
+    // MARK: - Properties
+
+    let rating: Int
+
+    private var normalizedRating: Int {
+        min(max(rating, 0), Constants.maxRating)
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(1...Constants.maxRating, id: \.self) { index in
+                Image(index <= normalizedRating ? .starActive : .starInactive)
+                    .renderingMode(.original)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: Constants.starSize, height: Constants.starSize)
+            }
+        }
+        .frame(width: Constants.totalWidth, height: Constants.starSize, alignment: .leading)
+    }
+}
+
+#Preview {
+    FavoriteNFTCell(
+        nft: ProfilePreviewData.nfts[0],
+        isRemoving: false,
+        onRemove: {}
+    )
+    .padding()
+}

--- a/iOS-FakeNFT-Extended/UI/Profile/Views/FavoriteNFTCell.swift
+++ b/iOS-FakeNFT-Extended/UI/Profile/Views/FavoriteNFTCell.swift
@@ -5,7 +5,6 @@
 //  Created by Анастасия Федотова on 19.05.2026.
 //
 
-import Kingfisher
 import SwiftUI
 
 struct FavoriteNFTCell: View {
@@ -55,7 +54,7 @@ struct FavoriteNFTCell: View {
                 .foregroundStyle(Color.ypBlack)
                 .lineLimit(1)
 
-            FavoriteRatingStarsView(rating: nft.rating ?? 0)
+            RatingStarsView(rating: nft.rating ?? 0)
                 .padding(.top, 4)
 
             Text(priceText)
@@ -83,112 +82,6 @@ struct FavoriteNFTCell: View {
         }
 
         return String(format: "%.2f ETH", locale: Locale(identifier: "ru_RU"), price)
-    }
-}
-
-// MARK: - FavoriteNFTImageView
-
-private struct FavoriteNFTImageView: View {
-
-    // MARK: - State
-
-    @State private var didFail = false
-
-    // MARK: - Properties
-
-    let url: URL?
-
-    // MARK: - Body
-
-    var body: some View {
-        ZStack {
-            if let url, !didFail {
-                KFImage(url)
-                    .placeholder {
-                        ZStack {
-                            Color.ypBackgroundUniversal
-
-                            LoadingSpinner(size: .medium, tint: .ypWhiteUniversal)
-                        }
-                    }
-                    .retry(maxCount: 2, interval: .seconds(1))
-                    .fade(duration: 0.2)
-                    .onFailure { _ in
-                        didFail = true
-                    }
-                    .resizable()
-                    .scaledToFill()
-            } else {
-                FavoriteNFTImagePlaceholder()
-            }
-        }
-        .frame(width: 80, height: 80)
-        .clipped()
-    }
-}
-
-// MARK: - FavoriteNFTImagePlaceholder
-
-private struct FavoriteNFTImagePlaceholder: View {
-
-    // MARK: - Constants
-
-    private enum Constants {
-        static let cellSize: CGFloat = 20
-        static let gridSize = 4
-    }
-
-    // MARK: - Body
-
-    var body: some View {
-        VStack(spacing: 0) {
-            ForEach(0..<Constants.gridSize, id: \.self) { row in
-                HStack(spacing: 0) {
-                    ForEach(0..<Constants.gridSize, id: \.self) { column in
-                        Rectangle()
-                            .fill((row + column).isMultiple(of: 2) ? Color.ypWhite : Color.ypBlack)
-                            .frame(width: Constants.cellSize, height: Constants.cellSize)
-                    }
-                }
-            }
-        }
-        .frame(width: 80, height: 80)
-    }
-}
-
-// MARK: - FavoriteRatingStarsView
-
-private struct FavoriteRatingStarsView: View {
-
-    // MARK: - Constants
-
-    private enum Constants {
-        static let maxRating = 5
-        static let starSize: CGFloat = 12
-        static let totalWidth: CGFloat = 60
-    }
-
-    // MARK: - Properties
-
-    let rating: Int
-
-    private var normalizedRating: Int {
-        min(max(rating, 0), Constants.maxRating)
-    }
-
-    // MARK: - Body
-
-    var body: some View {
-        HStack(spacing: 0) {
-            ForEach(1...Constants.maxRating, id: \.self) { index in
-                Image(index <= normalizedRating ? .starActive : .starInactive)
-                    .renderingMode(.original)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: Constants.starSize, height: Constants.starSize)
-            }
-        }
-        .frame(width: Constants.totalWidth, height: Constants.starSize, alignment: .leading)
     }
 }
 

--- a/iOS-FakeNFT-Extended/UI/Profile/Views/FavoriteNFTImageView.swift
+++ b/iOS-FakeNFT-Extended/UI/Profile/Views/FavoriteNFTImageView.swift
@@ -1,0 +1,91 @@
+//
+//  FavoriteNFTImageView.swift
+//  iOS-FakeNFT-Extended
+//
+//  Created by Анастасия Федотова on 21.05.2026.
+//
+
+import Kingfisher
+import SwiftUI
+
+struct FavoriteNFTImageView: View {
+
+    // MARK: - State
+
+    @State private var didFail = false
+
+    // MARK: - Properties
+
+    let url: URL?
+
+    // MARK: - Body
+
+    var body: some View {
+        ZStack {
+            if let url, !didFail {
+                KFImage(url)
+                    .placeholder {
+                        ZStack {
+                            Color.ypBackgroundUniversal
+
+                            LoadingSpinner(size: .medium, tint: .ypWhiteUniversal)
+                        }
+                    }
+                    .retry(maxCount: 2, interval: .seconds(1))
+                    .fade(duration: 0.2)
+                    .onFailure { _ in
+                        didFail = true
+                    }
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                FavoriteNFTImagePlaceholder()
+            }
+        }
+        .frame(width: Constants.imageSize, height: Constants.imageSize)
+        .clipped()
+    }
+
+    // MARK: - Constants
+
+    private enum Constants {
+        static let imageSize: CGFloat = 80
+    }
+}
+
+// MARK: - FavoriteNFTImagePlaceholder
+
+private struct FavoriteNFTImagePlaceholder: View {
+
+    // MARK: - Constants
+
+    private enum Constants {
+        static let cellSize: CGFloat = 20
+        static let gridSize = 4
+        static let imageSize: CGFloat = 80
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ForEach(0..<Constants.gridSize, id: \.self) { row in
+                HStack(spacing: 0) {
+                    ForEach(0..<Constants.gridSize, id: \.self) { column in
+                        Rectangle()
+                            .fill((row + column).isMultiple(of: 2) ? Color.ypWhite : Color.ypBlack)
+                            .frame(width: Constants.cellSize, height: Constants.cellSize)
+                    }
+                }
+            }
+        }
+        .frame(width: Constants.imageSize, height: Constants.imageSize)
+    }
+}
+
+#Preview {
+    FavoriteNFTImageView(url: nil)
+        .frame(width: 80, height: 80)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .padding()
+}

--- a/iOS-FakeNFT-Extended/UI/Profile/Views/FavoriteNFTsView.swift
+++ b/iOS-FakeNFT-Extended/UI/Profile/Views/FavoriteNFTsView.swift
@@ -20,16 +20,16 @@ struct FavoriteNFTsView: View {
     // MARK: - Initializers
 
     init(
-        profile: Profile,
+        favoriteIds: [String],
         nftService: NftServiceProtocol,
-        profileService: ProfileServiceProtocol,
+        updateFavoriteIds: @escaping ([String]) async throws -> Profile,
         onProfileUpdated: @escaping (Profile) -> Void
     ) {
         _viewModel = State(
             initialValue: FavoriteNFTsViewModel(
-                profile: profile,
+                favoriteIds: favoriteIds,
                 nftService: nftService,
-                profileService: profileService
+                updateFavoriteIds: updateFavoriteIds
             )
         )
         self.onProfileUpdated = onProfileUpdated
@@ -175,10 +175,26 @@ struct FavoriteNFTsView: View {
 #Preview {
     NavigationStack {
         FavoriteNFTsView(
-            profile: ProfilePreviewData.profile,
+            favoriteIds: ProfilePreviewData.profile.likes ?? [],
             nftService: MockNftService(),
-            profileService: MockProfileService(),
+            updateFavoriteIds: { favoriteIds in
+                ProfilePreviewData.profile.updatingLikes(favoriteIds)
+            },
             onProfileUpdated: { _ in }
+        )
+    }
+}
+
+private extension Profile {
+    func updatingLikes(_ likes: [String]) -> Profile {
+        Profile(
+            id: id,
+            name: name,
+            description: description,
+            website: website,
+            avatar: avatar,
+            nfts: nfts ?? [],
+            likes: likes
         )
     }
 }

--- a/iOS-FakeNFT-Extended/UI/Profile/Views/FavoriteNFTsView.swift
+++ b/iOS-FakeNFT-Extended/UI/Profile/Views/FavoriteNFTsView.swift
@@ -1,0 +1,184 @@
+//
+//  FavoriteNFTsView.swift
+//  iOS-FakeNFT-Extended
+//
+//  Created by Анастасия Федотова on 19.05.2026.
+//
+
+import SwiftUI
+
+struct FavoriteNFTsView: View {
+
+    // MARK: - State
+
+    @State private var viewModel: FavoriteNFTsViewModel
+
+    // MARK: - Properties
+
+    private let onProfileUpdated: (Profile) -> Void
+
+    // MARK: - Initializers
+
+    init(
+        profile: Profile,
+        nftService: NftServiceProtocol,
+        profileService: ProfileServiceProtocol,
+        onProfileUpdated: @escaping (Profile) -> Void
+    ) {
+        _viewModel = State(
+            initialValue: FavoriteNFTsViewModel(
+                profile: profile,
+                nftService: nftService,
+                profileService: profileService
+            )
+        )
+        self.onProfileUpdated = onProfileUpdated
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        content
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    Text(String(localized: "Profile.FavoriteNFTs.title"))
+                        .font(.bold17)
+                        .foregroundStyle(Color.ypBlack)
+                }
+            }
+            .alert(
+                String(localized: "Error.title"),
+                isPresented: removalErrorBinding
+            ) {
+                Button(String(localized: "Error.cancel"), role: .cancel) {
+                    viewModel.dismissRemovalError()
+                }
+
+                Button(String(localized: "Error.retry")) {
+                    Task {
+                        await retryRemovingFavorite()
+                    }
+                }
+            } message: {
+                Text(viewModel.removalErrorMessage ?? "")
+            }
+            .task {
+                await viewModel.loadNFTs()
+            }
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var content: some View {
+        switch viewModel.state {
+        case .idle, .loading:
+            LoadingSpinner(size: .medium)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Color.ypWhite)
+        case .loaded(let nfts):
+            favoritesGrid(nfts)
+        case .empty:
+            emptyContent
+        case .failed(let message):
+            errorContent(message)
+        }
+    }
+
+    private func favoritesGrid(_ nfts: [ProfileNft]) -> some View {
+        ScrollView {
+            LazyVGrid(
+                columns: [
+                    GridItem(.flexible(), spacing: 7),
+                    GridItem(.flexible(), spacing: 0)
+                ],
+                spacing: 20
+            ) {
+                ForEach(nfts, id: \.profileListID) { nft in
+                    FavoriteNFTCell(
+                        nft: nft,
+                        isRemoving: viewModel.pendingRemovalIds.contains(nft.id ?? "")
+                    ) {
+                        Task {
+                            await removeFromFavorites(nft)
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 20)
+            .padding(.bottom, 16)
+        }
+        .background(Color.ypWhite)
+    }
+
+    private var emptyContent: some View {
+        Text(String(localized: "Profile.FavoriteNFTs.empty"))
+            .font(.bold17)
+            .foregroundStyle(Color.ypBlack)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color.ypWhite)
+    }
+
+    private func errorContent(_ message: String) -> some View {
+        VStack(spacing: 16) {
+            Text(message)
+                .font(.bold17)
+                .foregroundStyle(Color.ypBlack)
+                .multilineTextAlignment(.center)
+
+            Button(String(localized: "Profile.retry")) {
+                Task {
+                    await viewModel.loadNFTs()
+                }
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.ypWhite)
+    }
+
+    // MARK: - Actions
+
+    private func removeFromFavorites(_ nft: ProfileNft) async {
+        guard let updatedProfile = await viewModel.removeFromFavorites(nft) else {
+            return
+        }
+
+        onProfileUpdated(updatedProfile)
+    }
+
+    private func retryRemovingFavorite() async {
+        guard let updatedProfile = await viewModel.retryFailedRemoval() else {
+            return
+        }
+
+        onProfileUpdated(updatedProfile)
+    }
+
+    // MARK: - Bindings
+
+    private var removalErrorBinding: Binding<Bool> {
+        Binding(
+            get: { viewModel.removalErrorMessage != nil },
+            set: { isPresented in
+                if !isPresented {
+                    viewModel.dismissRemovalError()
+                }
+            }
+        )
+    }
+}
+
+#Preview {
+    NavigationStack {
+        FavoriteNFTsView(
+            profile: ProfilePreviewData.profile,
+            nftService: MockNftService(),
+            profileService: MockProfileService(),
+            onProfileUpdated: { _ in }
+        )
+    }
+}

--- a/iOS-FakeNFT-Extended/UI/Profile/Views/MyNFTsRowView.swift
+++ b/iOS-FakeNFT-Extended/UI/Profile/Views/MyNFTsRowView.swift
@@ -188,42 +188,6 @@ private struct NFTImagePlaceholder: View {
     }
 }
 
-// MARK: - RatingStarsView
-
-private struct RatingStarsView: View {
-
-    // MARK: - Constants
-
-    private enum Constants {
-        static let maxRating = 5
-        static let starSize: CGFloat = 12
-        static let totalWidth: CGFloat = 60
-    }
-
-    // MARK: - Properties
-
-    let rating: Int
-
-    private var normalizedRating: Int {
-        min(max(rating, 0), Constants.maxRating)
-    }
-
-    // MARK: - Body
-
-    var body: some View {
-        HStack(spacing: 0) {
-            ForEach(1...Constants.maxRating, id: \.self) { index in
-                Image(index <= normalizedRating ? .starActive : .starInactive)
-                    .renderingMode(.original)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: Constants.starSize, height: Constants.starSize)
-            }
-        }
-        .frame(width: Constants.totalWidth, height: Constants.starSize, alignment: .leading)
-    }
-}
-
 // MARK: - ProfileNft
 
 extension ProfileNft {

--- a/iOS-FakeNFT-Extended/UI/Profile/Views/MyNFTsView.swift
+++ b/iOS-FakeNFT-Extended/UI/Profile/Views/MyNFTsView.swift
@@ -125,8 +125,8 @@ struct MyNFTsView: View {
 #Preview {
     NavigationStack {
         MyNFTsView(
-            nftIds: MockProfileService.nfts.compactMap(\.id),
-            nftService: MockProfileService()
+            nftIds: ProfilePreviewData.nfts.compactMap(\.id),
+            nftService: MockNftService()
         )
     }
 }

--- a/iOS-FakeNFT-Extended/UI/Profile/Views/ProfileView.swift
+++ b/iOS-FakeNFT-Extended/UI/Profile/Views/ProfileView.swift
@@ -77,7 +77,7 @@ struct ProfileView: View {
                     navigationRow(
                         title: String(localized: "Profile.favoriteNfts"),
                         count: profile.likes?.count ?? 0,
-                        route: .favorites
+                        route: .favorites(profile)
                     )
                 }
                 .padding(.top, 32)

--- a/iOS-FakeNFT-Extended/UI/Profile/Views/ProfileView.swift
+++ b/iOS-FakeNFT-Extended/UI/Profile/Views/ProfileView.swift
@@ -77,7 +77,7 @@ struct ProfileView: View {
                     navigationRow(
                         title: String(localized: "Profile.favoriteNfts"),
                         count: profile.likes?.count ?? 0,
-                        route: .favorites(profile)
+                        route: .favorites(profile.likes ?? [])
                     )
                 }
                 .padding(.top, 32)

--- a/iOS-FakeNFT-Extended/UI/Profile/Views/RatingStarsView.swift
+++ b/iOS-FakeNFT-Extended/UI/Profile/Views/RatingStarsView.swift
@@ -1,0 +1,51 @@
+//
+//  RatingStarsView.swift
+//  iOS-FakeNFT-Extended
+//
+//  Created by Анастасия Федотова on 21.05.2026.
+//
+
+import SwiftUI
+
+struct RatingStarsView: View {
+
+    // MARK: - Constants
+
+    private enum Constants {
+        static let maxRating = 5
+        static let starSize: CGFloat = 12
+        static let totalWidth: CGFloat = 60
+    }
+
+    // MARK: - Properties
+
+    let rating: Int
+
+    private var normalizedRating: Int {
+        min(max(rating, 0), Constants.maxRating)
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(1...Constants.maxRating, id: \.self) { index in
+                Image(index <= normalizedRating ? .starActive : .starInactive)
+                    .renderingMode(.original)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: Constants.starSize, height: Constants.starSize)
+            }
+        }
+        .frame(width: Constants.totalWidth, height: Constants.starSize, alignment: .leading)
+    }
+}
+
+#Preview {
+    VStack(alignment: .leading, spacing: 8) {
+        ForEach(0...5, id: \.self) { rating in
+            RatingStarsView(rating: rating)
+        }
+    }
+    .padding()
+}

--- a/iOS-FakeNFT-Extended/UI/TabBarView.swift
+++ b/iOS-FakeNFT-Extended/UI/TabBarView.swift
@@ -109,11 +109,11 @@ private struct ProfileTabRoot: View {
                             nftIds: nftIds,
                             nftService: nftService
                         )
-                    case .favorites(let profile):
+                    case .favorites(let favoriteIds):
                         FavoriteNFTsView(
-                            profile: profile,
+                            favoriteIds: favoriteIds,
                             nftService: nftService,
-                            profileService: profileService,
+                            updateFavoriteIds: viewModel.updateFavoriteIds,
                             onProfileUpdated: viewModel.updateLoadedProfile
                         )
                     case .edit(let profile):

--- a/iOS-FakeNFT-Extended/UI/TabBarView.swift
+++ b/iOS-FakeNFT-Extended/UI/TabBarView.swift
@@ -109,8 +109,13 @@ private struct ProfileTabRoot: View {
                             nftIds: nftIds,
                             nftService: nftService
                         )
-                    case .favorites:
-                        ProfilePlaceholderView(title: String(localized: "Profile.favoriteNfts"))
+                    case .favorites(let profile):
+                        FavoriteNFTsView(
+                            profile: profile,
+                            nftService: nftService,
+                            profileService: profileService,
+                            onProfileUpdated: viewModel.updateLoadedProfile
+                        )
                     case .edit(let profile):
                         EditProfileView(
                             profile: profile,

--- a/iOS-FakeNFT-Extended/en.lproj/Localizable.strings
+++ b/iOS-FakeNFT-Extended/en.lproj/Localizable.strings
@@ -45,3 +45,7 @@
 "Profile.MyNFTs.unknownAuthor" = "Автор не указан";
 "Profile.MyNFTs.noPrice" = "Цена не указана";
 "Profile.MyNFTs.price" = "Цена";
+"Profile.FavoriteNFTs.title" = "Избранные NFT";
+"Profile.FavoriteNFTs.empty" = "У вас ещё нет избранных NFT";
+"Profile.FavoriteNFTs.error.load" = "Не удалось загрузить избранные NFT: %@";
+"Profile.FavoriteNFTs.error.remove" = "Не удалось удалить NFT из избранного: %@";


### PR DESCRIPTION
**Что Сделано**

**Favorite NFT**

Добавлен экран избранных NFT:
- `FavoriteNFTsView`
- `FavoriteNFTsViewModel`
- `FavoriteNFTCell`

Реализована сетка избранных NFT:
- ячейка с изображением, лайком, названием, рейтингом и ценой

**Profile / Favorites**

Реализована загрузка избранных NFT из `profile.likes`.

Добавлено удаление NFT из избранного:
- локальное optimistic-обновление списка
- отправка обновленного `likes` через `ProfileService`
- откат состояния при ошибке
- повтор удаления через alert

Исправлена обработка удаления последнего лайка:
- для пустого массива `likes` в `UpdateProfileRequest` отправляется `likes=null`
- сервер корректно сохраняет пустой список избранного

**Networking**

Обновлен `UpdateProfileRequest`:
- добавлена корректная отправка пустого массива `likes`
- пустое избранное больше не приводит к ошибке сети

**UI / States**

Для экрана избранного реализованы:
- состояние загрузки
- состояние ошибки
- пустое состояние
- отображение данных
- alert при ошибке удаления
- кнопка повторной попытки удаления

**Routing**

Обновлен роут избранного:
- `favorites` теперь получает актуальный `Profile`
- экран избранного использует `profile.likes` как источник данных

Обновлен переход из профиля:
- количество избранных NFT берется из `profile.likes.count`
- после удаления лайка обновляется основной экран профиля

**Preview / Mock**

Улучшена структура моковых данных для превью:
- добавлен `ProfilePreviewData`
- `MockProfileService` отвечает только за профиль
- `MockNftService` отвечает только за NFT
---
**Материалы**

Декомпозиция эпика: https://github.com/users/asilenin/projects/1/views/1

[ProfileDecomposition.md](https://github.com/user-attachments/files/28056282/ProfileDecomposition.md)
